### PR TITLE
Astar devel

### DIFF
--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
@@ -90,7 +90,8 @@
 // calls them 6V motors, so Marco originally reduced the maximum PWM
 // based on using 7.4V batteries. But Ray looked up the motor specs and
 // found they are rated to 12V, so we'll use the maximum PWM available.
-#define MAX_PWM        400
+#define MAX_PWM        250 //  turn down for servos
+//#define MAX_PWM        400 
 
 #if defined(ARDUINO) && ARDUINO >= 100
 #include "Arduino.h"
@@ -440,6 +441,12 @@ void loop() {
 #ifdef USE_SERVOS
   int i;
   for (i = 0; i < N_SERVOS; i++) {
+    /*
+    SERIAL_STREAM.print("servo ");
+    SERIAL_STREAM.print(i);
+    SERIAL_STREAM.print(" read = ");
+    SERIAL_STREAM.println(servos[arg1].getServo().read());
+    */
     servos[i].doSweep();
   }
 #endif

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
@@ -336,9 +336,11 @@ void setup() {
 
 #ifdef USE_I2C
   initI2c();
+  /* for debugging w/ cmd, doesn't work w/ Pi
   while(!SERIAL_STREAM) {
     // do nothing
   }
+  */
 #else
   // if not I2C, wait for serial to start
   while (!SERIAL_STREAM) {

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ROSArduinoBridge.ino
@@ -224,7 +224,7 @@ int runCommand() {
     SERIAL_STREAM.println(BAUDRATE);
     break;
   case ANALOG_READ:
-    #ifdef USE_I2C //POLOLU_ASTAR_ROBOT_CONTROLLER
+    #ifdef defined(USE_I2C) && defined(POLOLU_ASTAR_ROBOT_CONTROLLER)
     if (arg1 == ASTAR_BATTERY_PIN) {
       SERIAL_STREAM.println(readBatteryMillivoltsLV());
       break;
@@ -233,7 +233,7 @@ int runCommand() {
     SERIAL_STREAM.println(analogRead(arg1));
     break;
   case DIGITAL_READ:
-    #ifdef USE_I2C //POLOLU_ASTAR_ROBOT_CONTROLLER
+    #ifdef defined(USE_I2C) && defined(POLOLU_ASTAR_ROBOT_CONTROLLER)
     if (arg1 == ASTAR_BTN_A_PIN) {
       SERIAL_STREAM.println(buttonA.isPressed());
       break;
@@ -252,7 +252,7 @@ int runCommand() {
     SERIAL_STREAM.println("OK");
     break;
   case DIGITAL_WRITE:
-    #ifdef USE_I2C //POLOLU_ASTAR_ROBOT_CONTROLLER
+    #ifdef defined(USE_I2C) && defined(POLOLU_ASTAR_ROBOT_CONTROLLER)
     if (arg1 == ASTAR_YELLOW_LED_PIN) {
       ledYellow(arg2);
       SERIAL_STREAM.println("OK");
@@ -336,11 +336,6 @@ void setup() {
 
 #ifdef USE_I2C
   initI2c();
-  /* for debugging w/ cmd, doesn't work w/ Pi
-  while(!SERIAL_STREAM) {
-    // do nothing
-  }
-  */
 #else
   // if not I2C, wait for serial to start
   while (!SERIAL_STREAM) {
@@ -348,7 +343,7 @@ void setup() {
   }
 #endif
 
-SERIAL_STREAM.println("Ready!");
+  SERIAL_STREAM.println("Ready!");
 
 // Initialize the motor controller if used */
 #ifdef USE_BASE
@@ -364,7 +359,7 @@ SERIAL_STREAM.println("Ready!");
       servos[i].initServo(
           servoPins[i],
           stepDelay[i],
-          servoInitPosition[i]);          
+          servoInitPosition[i]);
     }
   #endif
 }
@@ -422,7 +417,7 @@ void loop() {
 #ifdef USE_BASE
   if (millis() > nextPID) {
     updatePID();
-    /*  for debugging:
+    /* for debugging:
     if (moving != 0) {
       SERIAL_STREAM.print("out = ");
       SERIAL_STREAM.print(leftPID.output);
@@ -441,7 +436,7 @@ void loop() {
       SERIAL_STREAM.print(" rpE= ");
       SERIAL_STREAM.println(rightPID.PrevEnc);
     }
-    */ 
+    */
     nextPID += PID_INTERVAL;
   }
 

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/Servo.cpp
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/Servo.cpp
@@ -1,0 +1,319 @@
+/*
+ Servo.cpp - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+ Copyright (c) 2009 Michael Margolis.  All right reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#if defined(ARDUINO_ARCH_AVR)
+
+#include <avr/interrupt.h>
+#include <Arduino.h>
+
+#include "Servo.h"
+
+#define usToTicks(_us)    (( clockCyclesPerMicrosecond()* _us) / 8)     // converts microseconds to tick (assumes prescale of 8)  // 12 Aug 2009
+#define ticksToUs(_ticks) (( (unsigned)_ticks * 8)/ clockCyclesPerMicrosecond() ) // converts from ticks back to microseconds
+
+
+#define TRIM_DURATION       2                               // compensation ticks to trim adjust for digitalWrite delays // 12 August 2009
+
+//#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
+
+static servo_t servos[MAX_SERVOS];                          // static array of servo structures
+static volatile int8_t Channel[_Nbr_16timers ];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
+
+uint8_t ServoCount = 0;                                     // the total number of attached servos
+
+
+// convenience macros
+#define SERVO_INDEX_TO_TIMER(_servo_nbr) ((timer16_Sequence_t)(_servo_nbr / SERVOS_PER_TIMER)) // returns the timer controlling this servo
+#define SERVO_INDEX_TO_CHANNEL(_servo_nbr) (_servo_nbr % SERVOS_PER_TIMER)       // returns the index of the servo on this timer
+#define SERVO_INDEX(_timer,_channel)  ((_timer*SERVOS_PER_TIMER) + _channel)     // macro to access servo index by timer and channel
+#define SERVO(_timer,_channel)  (servos[SERVO_INDEX(_timer,_channel)])            // macro to access servo class by timer and channel
+
+#define SERVO_MIN() (MIN_PULSE_WIDTH - this->min * 4)  // minimum value in uS for this servo
+#define SERVO_MAX() (MAX_PULSE_WIDTH - this->max * 4)  // maximum value in uS for this servo
+
+/************ static functions common to all instances ***********************/
+
+static inline void handle_interrupts(timer16_Sequence_t timer, volatile uint16_t *TCNTn, volatile uint16_t* OCRnA)
+{
+  if( Channel[timer] < 0 )
+    *TCNTn = 0; // channel set to -1 indicated that refresh interval completed so reset the timer
+  else{
+    if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && SERVO(timer,Channel[timer]).Pin.isActive == true )
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,LOW); // pulse this channel low if activated
+  }
+
+  Channel[timer]++;    // increment to the next channel
+  if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
+    *OCRnA = *TCNTn + SERVO(timer,Channel[timer]).ticks;
+    if(SERVO(timer,Channel[timer]).Pin.isActive == true)     // check if activated
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // its an active channel so pulse it high
+  }
+  else {
+    // finished all channels so wait for the refresh period to expire before starting over
+    if( ((unsigned)*TCNTn) + 4 < usToTicks(REFRESH_INTERVAL) )  // allow a few ticks to ensure the next OCR1A not missed
+      *OCRnA = (unsigned int)usToTicks(REFRESH_INTERVAL);
+    else
+      *OCRnA = *TCNTn + 4;  // at least REFRESH_INTERVAL has elapsed
+    Channel[timer] = -1; // this will get incremented at the end of the refresh period to start again at the first channel
+  }
+}
+
+#ifndef WIRING // Wiring pre-defines signal handlers so don't define any if compiling for the Wiring platform
+// Interrupt handlers for Arduino
+#if defined(_useTimer1)
+SIGNAL (TIMER1_COMPA_vect)
+{
+  handle_interrupts(_timer1, &TCNT1, &OCR1A);
+}
+#endif
+
+#if defined(_useTimer3)
+SIGNAL (TIMER3_COMPA_vect)
+{
+  handle_interrupts(_timer3, &TCNT3, &OCR3A);
+}
+#endif
+
+#if defined(_useTimer4)
+SIGNAL (TIMER4_COMPA_vect)
+{
+  handle_interrupts(_timer4, &TCNT4, &OCR4A);
+}
+#endif
+
+#if defined(_useTimer5)
+SIGNAL (TIMER5_COMPA_vect)
+{
+  handle_interrupts(_timer5, &TCNT5, &OCR5A);
+}
+#endif
+
+#elif defined WIRING
+// Interrupt handlers for Wiring
+#if defined(_useTimer1)
+void Timer1Service()
+{
+  handle_interrupts(_timer1, &TCNT1, &OCR1A);
+}
+#endif
+#if defined(_useTimer3)
+void Timer3Service()
+{
+  handle_interrupts(_timer3, &TCNT3, &OCR3A);
+}
+#endif
+#endif
+
+
+static void initISR(timer16_Sequence_t timer)
+{
+#if defined (_useTimer1)
+  if(timer == _timer1) {
+    TCCR1A = 0;             // normal counting mode
+    TCCR1B = _BV(CS11);     // set prescaler of 8
+    TCNT1 = 0;              // clear the timer count
+#if defined(__AVR_ATmega8__)|| defined(__AVR_ATmega128__)
+    TIFR |= _BV(OCF1A);      // clear any pending interrupts;
+    TIMSK |=  _BV(OCIE1A) ;  // enable the output compare interrupt
+#else
+    // here if not ATmega8 or ATmega128
+    TIFR1 |= _BV(OCF1A);     // clear any pending interrupts;
+    TIMSK1 |=  _BV(OCIE1A) ; // enable the output compare interrupt
+#endif
+#if defined(WIRING)
+    timerAttach(TIMER1OUTCOMPAREA_INT, Timer1Service);
+#endif
+  }
+#endif
+
+#if defined (_useTimer3)
+  if(timer == _timer3) {
+    TCCR3A = 0;             // normal counting mode
+    TCCR3B = _BV(CS31);     // set prescaler of 8
+    TCNT3 = 0;              // clear the timer count
+#if defined(__AVR_ATmega128__)
+    TIFR |= _BV(OCF3A);     // clear any pending interrupts;
+	ETIMSK |= _BV(OCIE3A);  // enable the output compare interrupt
+#else
+    TIFR3 = _BV(OCF3A);     // clear any pending interrupts;
+    TIMSK3 =  _BV(OCIE3A) ; // enable the output compare interrupt
+#endif
+#if defined(WIRING)
+    timerAttach(TIMER3OUTCOMPAREA_INT, Timer3Service);  // for Wiring platform only
+#endif
+  }
+#endif
+
+#if defined (_useTimer4)
+  if(timer == _timer4) {
+    TCCR4A = 0;             // normal counting mode
+    TCCR4B = _BV(CS41);     // set prescaler of 8
+    TCNT4 = 0;              // clear the timer count
+    TIFR4 = _BV(OCF4A);     // clear any pending interrupts;
+    TIMSK4 =  _BV(OCIE4A) ; // enable the output compare interrupt
+  }
+#endif
+
+#if defined (_useTimer5)
+  if(timer == _timer5) {
+    TCCR5A = 0;             // normal counting mode
+    TCCR5B = _BV(CS51);     // set prescaler of 8
+    TCNT5 = 0;              // clear the timer count
+    TIFR5 = _BV(OCF5A);     // clear any pending interrupts;
+    TIMSK5 =  _BV(OCIE5A) ; // enable the output compare interrupt
+  }
+#endif
+}
+
+static void finISR(timer16_Sequence_t timer)
+{
+    //disable use of the given timer
+#if defined WIRING   // Wiring
+  if(timer == _timer1) {
+    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+    TIMSK1 &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
+    #else
+    TIMSK &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
+    #endif
+    timerDetach(TIMER1OUTCOMPAREA_INT);
+  }
+  else if(timer == _timer3) {
+    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+    TIMSK3 &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+    #else
+    ETIMSK &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+    #endif
+    timerDetach(TIMER3OUTCOMPAREA_INT);
+  }
+#else
+  //For arduino - in future: call here to a currently undefined function to reset the timer
+  (void) timer;  // squash "unused parameter 'timer' [-Wunused-parameter]" warning
+#endif
+}
+
+static boolean isTimerActive(timer16_Sequence_t timer)
+{
+  // returns true if any servo is active on this timer
+  for(uint8_t channel=0; channel < SERVOS_PER_TIMER; channel++) {
+    if(SERVO(timer,channel).Pin.isActive == true)
+      return true;
+  }
+  return false;
+}
+
+
+/****************** end of static functions ******************************/
+
+Servo::Servo()
+{
+  if( ServoCount < MAX_SERVOS) {
+    this->servoIndex = ServoCount++;                    // assign a servo index to this instance
+	servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
+  }
+  else
+    this->servoIndex = INVALID_SERVO ;  // too many servos
+}
+
+uint8_t Servo::attach(int pin)
+{
+  // Serial.println("attached");
+  return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
+}
+
+uint8_t Servo::attach(int pin, int min, int max)
+{
+  if(this->servoIndex < MAX_SERVOS ) {
+    pinMode( pin, OUTPUT) ;                                   // set servo pin to output
+    servos[this->servoIndex].Pin.nbr = pin;
+    // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
+    this->min  = (MIN_PULSE_WIDTH - min)/4; //resolution of min/max is 4 uS
+    this->max  = (MAX_PULSE_WIDTH - max)/4;
+    // initialize the timer if it has not already been initialized
+    timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
+    if(isTimerActive(timer) == false)
+      initISR(timer);
+    servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
+  }
+  return this->servoIndex ;
+}
+
+void Servo::detach()
+{
+  servos[this->servoIndex].Pin.isActive = false;
+  timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
+  if(isTimerActive(timer) == false) {
+    finISR(timer);
+  }
+}
+
+void Servo::write(int value)
+{
+  if(value < MIN_PULSE_WIDTH)
+  {  // treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
+    if(value < 0) value = 0;
+    if(value > 180) value = 180;
+    value = map(value, 0, 180, SERVO_MIN(),  SERVO_MAX());
+  }
+  this->writeMicroseconds(value);
+}
+
+void Servo::writeMicroseconds(int value)
+{
+  // calculate and store the values for the given channel
+  byte channel = this->servoIndex;
+  if( (channel < MAX_SERVOS) )   // ensure channel is valid
+  {
+    if( value < SERVO_MIN() )          // ensure pulse width is valid
+      value = SERVO_MIN();
+    else if( value > SERVO_MAX() )
+      value = SERVO_MAX();
+
+    value = value - TRIM_DURATION;
+    value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
+
+    uint8_t oldSREG = SREG;
+    cli();
+    servos[channel].ticks = value;
+    SREG = oldSREG;
+  }
+}
+
+int Servo::read() // return the value as degrees
+{
+  return  map( this->readMicroseconds()+1, SERVO_MIN(), SERVO_MAX(), 0, 180);
+}
+
+int Servo::readMicroseconds()
+{
+  unsigned int pulsewidth;
+  if( this->servoIndex != INVALID_SERVO )
+    pulsewidth = ticksToUs(servos[this->servoIndex].ticks)  + TRIM_DURATION ;   // 12 aug 2009
+  else
+    pulsewidth  = 0;
+
+  return pulsewidth;
+}
+
+bool Servo::attached()
+{
+  return servos[this->servoIndex].Pin.isActive ;
+}
+
+#endif // ARDUINO_ARCH_AVR
+

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/Servo.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/Servo.h
@@ -1,0 +1,112 @@
+/*
+  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+  Copyright (c) 2009 Michael Margolis.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/* 
+  A servo is activated by creating an instance of the Servo class passing 
+  the desired pin to the attach() method.
+  The servos are pulsed in the background using the value most recently 
+  written using the write() method.
+
+  Note that analogWrite of PWM on pins associated with the timer are 
+  disabled when the first servo is attached.
+  Timers are seized as needed in groups of 12 servos - 24 servos use two 
+  timers, 48 servos will use four.
+  The sequence used to sieze timers is defined in timers.h
+
+  The methods are:
+
+    Servo - Class for manipulating servo motors connected to Arduino pins.
+
+    attach(pin )  - Attaches a servo motor to an i/o pin.
+    attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
+    default min is 544, max is 2400  
+ 
+    write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
+    writeMicroseconds() - Sets the servo pulse width in microseconds 
+    read()      - Gets the last written servo pulse width as an angle between 0 and 180. 
+    readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
+    attached()  - Returns true if there is a servo attached. 
+    detach()    - Stops an attached servos from pulsing its i/o pin. 
+ */
+
+#ifndef Servo_h
+#define Servo_h
+
+#include <inttypes.h>
+
+/* 
+ * Defines for 16 bit timers used with  Servo library 
+ *
+ * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
+ * timer16_Sequence_t enumerates the sequence that the timers should be allocated
+ * _Nbr_16timers indicates how many 16 bit timers are available.
+ */
+
+// Architecture specific include
+#if defined(ARDUINO_ARCH_AVR)
+#include "ServoTimers.h"
+#elif defined(ARDUINO_ARCH_SAM)
+#include "sam/ServoTimers.h"
+#elif defined(ARDUINO_ARCH_SAMD)
+#include "samd/ServoTimers.h"
+#else
+#error "This library only supports boards with an AVR, SAM or SAMD processor."
+#endif
+
+#define Servo_VERSION           2     // software version of this library
+
+#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo  
+#define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo 
+#define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
+#define REFRESH_INTERVAL    20000     // minumim time to refresh servos in microseconds 
+
+#define SERVOS_PER_TIMER       12     // the maximum number of servos controlled by one timer 
+#define MAX_SERVOS   (_Nbr_16timers  * SERVOS_PER_TIMER)
+
+#define INVALID_SERVO         255     // flag indicating an invalid servo index
+
+typedef struct  {
+  uint8_t nbr        :6 ;             // a pin number from 0 to 63
+  uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
+} ServoPin_t   ;  
+
+typedef struct {
+  ServoPin_t Pin;
+  volatile unsigned int ticks;
+} servo_t;
+
+class Servo
+{
+public:
+  Servo();
+  uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
+  uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
+  void detach();
+  void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
+  void writeMicroseconds(int value); // Write pulse width in microseconds 
+  int read();                        // returns current pulse width as an angle between 0 and 180 degrees
+  int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
+  bool attached();                   // return true if this servo is attached, otherwise false 
+private:
+   uint8_t servoIndex;               // index into the channel data for this servo
+   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
+   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+};
+
+#endif

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ServoTimers.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/ServoTimers.h
@@ -1,0 +1,59 @@
+/*
+  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+  Copyright (c) 2009 Michael Margolis.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
+ * Defines for 16 bit timers used with  Servo library
+ *
+ * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
+ * timer16_Sequence_t enumerates the sequence that the timers should be allocated
+ * _Nbr_16timers indicates how many 16 bit timers are available.
+ */
+
+/**
+ * AVR Only definitions
+ * --------------------
+ */
+
+// Say which 16 bit timers can be used and in what order
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#define _useTimer5
+#define _useTimer1
+#define _useTimer3
+#define _useTimer4
+typedef enum { _timer5, _timer1, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t;
+
+#elif defined(__AVR_ATmega32U4__)
+#define _useTimer3
+typedef enum { _timer3, _Nbr_16timers } timer16_Sequence_t;
+
+#elif defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__)
+#define _useTimer3
+#define _useTimer1
+typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t;
+
+#elif defined(__AVR_ATmega128__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega2561__)
+#define _useTimer3
+#define _useTimer1
+typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t;
+
+#else  // everything else
+#define _useTimer1
+typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t;
+#endif
+

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
@@ -102,12 +102,14 @@ void runI2c() {
 
 #ifdef USE_SERVOS
   // servo values vary from 0 to 180 degrees:
-  if (slave.buffer.set_left_servo < 181 || slave.buffer.set_right_servo < 181) {
+  if (slave.buffer.set_left_servo < 181) {
     servos[0].setTargetPosition(slave.buffer.set_left_servo);
-    servos[1].setTargetPosition(slave.buffer.set_right_servo);
     slave.buffer.set_left_servo = 200;
-    slave.buffer.set_right_servo = 200;
   }
+  if (slave.buffer.set_right_servo < 181) {
+    servos[1].setTargetPosition(slave.buffer.set_right_servo);
+    slave.buffer.set_right_servo = 200;
+  }  
   slave.buffer.get_left_servo = servos[0].currentPositionDegrees;
   slave.buffer.get_right_servo = servos[1].currentPositionDegrees;
 #endif

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
@@ -15,7 +15,6 @@
  * 10/16/2016
  */
 
-#include <Servo.h>
 #include <AStar32U4.h>
 #include <PololuRPiSlave.h>
 
@@ -56,6 +55,9 @@ void initI2c() {
   slave.buffer.Ki = Ki;
   slave.buffer.Kd = Kd;
   slave.buffer.Ko = Ko;
+
+  slave.buffer.left_servo = -1;
+  slave.buffer.right_servo = -1;
 
   // Play startup sound.
   buzzer.play("v10>>g16>>>c16");
@@ -98,8 +100,12 @@ void runI2c() {
   slave.buffer.rightEncoder = readEncoder(RIGHT);
 
 #ifdef USE_SERVOS
-  servos[0].setTargetPosition(slave.buffer.left_servo);
-  servos[1].setTargetPosition(slave.buffer.right_servo);
+  if (slave.buffer.left_servo > -1 || slave.buffer.right_servo > -1) {
+    servos[0].setTargetPosition(slave.buffer.left_servo);
+    servos[1].setTargetPosition(slave.buffer.right_servo);
+    slave.buffer.left_servo = -1;
+    slave.buffer.right_servo = -1;
+  }
 #endif
 
   // Playing music involves both reading and writing, since we only

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
@@ -31,7 +31,8 @@ struct Data
   int32_t leftEncoder, rightEncoder;
   int16_t Kp, Ki, Kd, Ko; // PID values
 
-  int16_t left_servo, right_servo;
+  int8_t set_left_servo, set_right_servo;
+  int8_t get_left_servo, get_right_servo;
 
   bool playNotes;
   char notes[14];
@@ -100,12 +101,15 @@ void runI2c() {
   slave.buffer.rightEncoder = readEncoder(RIGHT);
 
 #ifdef USE_SERVOS
-  if (slave.buffer.left_servo > -1 || slave.buffer.right_servo > -1) {
-    servos[0].setTargetPosition(slave.buffer.left_servo);
-    servos[1].setTargetPosition(slave.buffer.right_servo);
-    slave.buffer.left_servo = -1;
-    slave.buffer.right_servo = -1;
+  // servo values vary from 0 to 180 degrees:
+  if (slave.buffer.set_left_servo < 181 || slave.buffer.set_right_servo < 181) {
+    servos[0].setTargetPosition(slave.buffer.set_left_servo);
+    servos[1].setTargetPosition(slave.buffer.set_right_servo);
+    slave.buffer.set_left_servo = 200;
+    slave.buffer.set_right_servo = 200;
   }
+  slave.buffer.get_left_servo = servos[0].currentPositionDegrees;
+  slave.buffer.get_right_servo = servos[1].currentPositionDegrees;
 #endif
 
   // Playing music involves both reading and writing, since we only

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/pI2C.h
@@ -31,8 +31,8 @@ struct Data
   int32_t leftEncoder, rightEncoder;
   int16_t Kp, Ki, Kd, Ko; // PID values
 
-  int8_t set_left_servo, set_right_servo;
-  int8_t get_left_servo, get_right_servo;
+  uint8_t set_left_servo, set_right_servo;
+  uint8_t get_left_servo, get_right_servo;
 
   bool playNotes;
   char notes[14];
@@ -57,8 +57,8 @@ void initI2c() {
   slave.buffer.Kd = Kd;
   slave.buffer.Ko = Ko;
 
-  slave.buffer.left_servo = -1;
-  slave.buffer.right_servo = -1;
+  slave.buffer.set_left_servo = 200;
+  slave.buffer.set_right_servo = 200;
 
   // Play startup sound.
   buzzer.play("v10>>g16>>>c16");

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
@@ -10,13 +10,13 @@
 // Decreasing this number will make the servo sweep more quickly.
 // Zero is the default number and will make the servos spin at
 // full speed.  150 ms makes them spin very slowly.
-int stepDelay [N_SERVOS] = { 0, 0 }; // ms
+int stepDelay [N_SERVOS] = { 20, 20 }; // ms
 
 // Pins
 byte servoPins [N_SERVOS] = { 5, 12}; // { 3, 4 };
 
 // Initial Position
-byte servoInitPosition [N_SERVOS] = { 90, 90 }; // [0, 180] degrees
+byte servoInitPosition [N_SERVOS] = { 45, 45}; //90, 90 }; // [0, 180] degrees
 
 
 class SweepServo

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
@@ -16,7 +16,7 @@ int stepDelay [N_SERVOS] = { 10, 10 }; // ms
 byte servoPins [N_SERVOS] = { 1, 5}; //5 }; //5 }; //, 12};
 
 // Initial Position
-int /*byte*/ servoInitPosition [N_SERVOS] = { 90, 90}; // [0, 180] degrees
+uint8_t /*byte*/ servoInitPosition [N_SERVOS] = { 90, 90}; // [0, 180] degrees
 
 
 class SweepServo
@@ -28,13 +28,13 @@ class SweepServo
         int stepDelayMs,
         int initPosition);
     void doSweep();
-    void setTargetPosition(int position);
+    void setTargetPosition(uint8_t position);
     Servo getServo();
+    uint8_t currentPositionDegrees;
 
   private:
     Servo servo;
     int stepDelayMs;
-    int currentPositionDegrees;
     int targetPositionDegrees;
     long lastSweepCommand;
 };

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
@@ -10,13 +10,13 @@
 // Decreasing this number will make the servo sweep more quickly.
 // Zero is the default number and will make the servos spin at
 // full speed.  150 ms makes them spin very slowly.
-int stepDelay [N_SERVOS] = { 20, 20 }; // ms
+int stepDelay [N_SERVOS] = { 10, 10 }; // ms
 
 // Pins
-byte servoPins [N_SERVOS] = { 5, 12}; // { 3, 4 };
+byte servoPins [N_SERVOS] = { 1, 5}; //5 }; //5 }; //, 12};
 
 // Initial Position
-byte servoInitPosition [N_SERVOS] = { 45, 45}; //90, 90 }; // [0, 180] degrees
+int /*byte*/ servoInitPosition [N_SERVOS] = { 90, 90}; // [0, 180] degrees
 
 
 class SweepServo

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
@@ -13,10 +13,10 @@
 int stepDelay [N_SERVOS] = { 10, 10 }; // ms
 
 // Pins
-byte servoPins [N_SERVOS] = { 4, 5}; //{1, 5};
+uint8_t servoPins [N_SERVOS] = { 4, 5};
 
 // Initial Position
-uint8_t /*byte*/ servoInitPosition [N_SERVOS] = { 90, 90}; // [0, 180] degrees
+uint8_t servoInitPosition [N_SERVOS] = { 90, 90}; // [0, 180] degrees
 
 
 class SweepServo

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.h
@@ -13,7 +13,7 @@
 int stepDelay [N_SERVOS] = { 10, 10 }; // ms
 
 // Pins
-byte servoPins [N_SERVOS] = { 1, 5}; //5 }; //5 }; //, 12};
+byte servoPins [N_SERVOS] = { 4, 5}; //{1, 5};
 
 // Initial Position
 uint8_t /*byte*/ servoInitPosition [N_SERVOS] = { 90, 90}; // [0, 180] degrees

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.ino
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.ino
@@ -31,6 +31,7 @@ void SweepServo::initServo(
   this->stepDelayMs = stepDelayMs;
   this->currentPositionDegrees = initPosition;
   this->targetPositionDegrees = initPosition;
+  this->servo.write(initPosition);
   this->lastSweepCommand = millis();
 }
 

--- a/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.ino
+++ b/ros_arduino_firmware/src/libraries/ROSArduinoBridge/servos.ino
@@ -63,7 +63,7 @@ void SweepServo::doSweep()
 
 
 // Set a new target position
-void SweepServo::setTargetPosition(int position)
+void SweepServo::setTargetPosition(uint8_t position)
 {
   this->targetPositionDegrees = position;
 }

--- a/ros_arduino_python/src/ros_arduino_python/a_star.py
+++ b/ros_arduino_python/src/ros_arduino_python/a_star.py
@@ -83,7 +83,7 @@ class AStar(object):
   def update_pid(self, Kp, Kd, Ki, Ko):
     self.write_pack(33,"hhhh", Kp, Kd, Ki, Ko)
 
- def write_servos(self, left_srv, right_srv):
+  def write_servos(self, left_srv, right_srv):
      self.write_pack(41, 'hh', left_srv, right_srv)
 
   def play_notes(self, notes):

--- a/ros_arduino_python/src/ros_arduino_python/a_star.py
+++ b/ros_arduino_python/src/ros_arduino_python/a_star.py
@@ -84,8 +84,11 @@ class AStar(object):
     self.write_pack(33,"hhhh", Kp, Kd, Ki, Ko)
 
   def write_servos(self, left_srv, right_srv):
-     self.write_pack(41, 'hh', left_srv, right_srv)
+     self.write_pack(41, 'cc', left_srv, right_srv)
 
+  def read_servos(self):
+    return self.read_unpack(43, 2, 'cc')
+     
   def play_notes(self, notes):
     self.write_pack(45, 'B15s', 1, notes.encode("ascii"))
 

--- a/ros_arduino_python/src/ros_arduino_python/a_star.py
+++ b/ros_arduino_python/src/ros_arduino_python/a_star.py
@@ -86,9 +86,15 @@ class AStar(object):
   def write_servos(self, left_srv, right_srv):
      self.write_pack(41, 'BB', left_srv, right_srv)
 
+  def write_servo_left(self, left_srv):
+      self.write_pack(41, 'B', left_srv)
+
+  def write_servo_right(self, right_srv):
+      self.write_pack(42, 'B', right_srv)
+
   def read_servos(self):
     return self.read_unpack(43, 2, 'BB')
-     
+
   def play_notes(self, notes):
     self.write_pack(45, 'B15s', 1, notes.encode("ascii"))
 

--- a/ros_arduino_python/src/ros_arduino_python/a_star.py
+++ b/ros_arduino_python/src/ros_arduino_python/a_star.py
@@ -84,10 +84,10 @@ class AStar(object):
     self.write_pack(33,"hhhh", Kp, Kd, Ki, Ko)
 
   def write_servos(self, left_srv, right_srv):
-     self.write_pack(41, 'cc', left_srv, right_srv)
+     self.write_pack(41, 'BB', left_srv, right_srv)
 
   def read_servos(self):
-    return self.read_unpack(43, 2, 'cc')
+    return self.read_unpack(43, 2, 'BB')
      
   def play_notes(self, notes):
     self.write_pack(45, 'B15s', 1, notes.encode("ascii"))

--- a/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
+++ b/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
@@ -221,13 +221,13 @@ if __name__ == "__main__":
     left_srv, rght_srv = myArduino.a_star.read_servos()
     print "Servos: left = ", left_srv, " right = ", rght_srv
     myArduino.a_star.write_servos(120, 60);
-    time.sleep(0.2);
+    time.sleep(1.0);
 
     left_srv, rght_srv = myArduino.a_star.read_servos()
     print "Servos: left = ", left_srv, " right = ", rght_srv
     
     myArduino.a_star.write_servos(150, 30);
-    time.sleep(0.2);
+    time.sleep(1.0);
 
     left_srv, rght_srv = myArduino.a_star.read_servos()
     print "Servos: left = ", left_srv, " right = ", rght_srv

--- a/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
+++ b/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
@@ -217,6 +217,11 @@ if __name__ == "__main__":
     myArduino.a_star.leds(0,0,0)
     #print "Current encoder counts", myArduino.encoders()
 
+    print "Move servoes:"
+    myArduino.a_star.write_servos(120, 60);
+    time.sleep(0.1);
+    myArduino.a_star.write_servos(150, 30);
+    
     print "Connection test successful.",
 
     print "Shutting down Arduino."

--- a/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
+++ b/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
@@ -218,9 +218,19 @@ if __name__ == "__main__":
     #print "Current encoder counts", myArduino.encoders()
 
     print "Move servoes:"
+    left_srv, rght_srv = myArduino.a_star.read_servos()
+    print "Servos: left = ", left_srv, " right = ", rght_srv
     myArduino.a_star.write_servos(120, 60);
-    time.sleep(0.1);
+    time.sleep(0.2);
+
+    left_srv, rght_srv = myArduino.a_star.read_servos()
+    print "Servos: left = ", left_srv, " right = ", rght_srv
+    
     myArduino.a_star.write_servos(150, 30);
+    time.sleep(0.2);
+
+    left_srv, rght_srv = myArduino.a_star.read_servos()
+    print "Servos: left = ", left_srv, " right = ", rght_srv
     
     print "Connection test successful.",
 

--- a/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
+++ b/ros_arduino_python/src/ros_arduino_python/arduino_a_starbus.py
@@ -151,14 +151,24 @@ class ArduinoAStarBus(Arduino):
 
     def servo_write(self, id, pos):
         ''' Usage: servo_write(id, pos)
-            Position is given in radians and converted to degrees before sending
+            Position in degrees (integer between 0 & 180)
         '''
+        if id == 0:
+            self.mutex.acquire()
+            self.a_star.write_servo_left(pos)
+            self.mutex.release()
+        elif id == 1:
+            self.mutex.acquire()
+            self.a_star.write_servo_right(pos)
+            self.mutex.release()
         return True
 
     def servo_read(self, id):
         ''' Usage: servo_read(id)
-            The returned position is converted from degrees to radians
+            Position in degrees (integer between 0 & 180)
         '''
+        if id >= 0 and id < 2:
+            return self.a_star.read_servos()[id]
         return 0
 
     def ping(self, pin):
@@ -225,13 +235,13 @@ if __name__ == "__main__":
 
     left_srv, rght_srv = myArduino.a_star.read_servos()
     print "Servos: left = ", left_srv, " right = ", rght_srv
-    
+
     myArduino.a_star.write_servos(150, 30);
     time.sleep(1.0);
 
     left_srv, rght_srv = myArduino.a_star.read_servos()
     print "Servos: left = ", left_srv, " right = ", rght_srv
-    
+
     print "Connection test successful.",
 
     print "Shutting down Arduino."


### PR DESCRIPTION
Includes changes to run servos from ROS on the A-star 32U4 thru I2C.  Key changes:
- adds Arduino Servo.h, ServoTimers.h & Servo.cpp files customized to use 32U4 Timer 3 (Timer 1 is used by motors).
- if USE_SERVOS is set, add two servos on pins 4 & 5 (see servos.h).
- if USE_SERVOS is set pI2C.h sends/receives servo info thru I2C buffer.
- arduino_a_starbus.py has python code for the Raspberry Pi to control two servos via I2C.